### PR TITLE
Fix Varien Autoload unregister in the case when it was already unregistered

### DIFF
--- a/app/code/community/Checkoutcom/Ckopayment/Model/Autoloader.php
+++ b/app/code/community/Checkoutcom/Ckopayment/Model/Autoloader.php
@@ -28,13 +28,17 @@ class Checkoutcom_Ckopayment_Model_Autoloader extends Varien_Event_Observer
         }
 
         //remove the Varien_Autoloader from the stack
-        spl_autoload_unregister($original_autoload);
+        if (!is_null($original_autoload)) {
+            spl_autoload_unregister($original_autoload);
+        }
 
         //register CKO autoloader, which gets on the stack first
         require_once Mage::getBaseDir('lib') . "/checkout-sdk-php/checkout.php";
         $autoLoader->pushAutoloader(array('checkout', 'load'), true);
 
         //IMPORTANT: add the Varien_Autoloader back to the stack
-        spl_autoload_register($original_autoload);
+        if (!is_null($original_autoload)) {
+            spl_autoload_register($original_autoload);
+        }
     }
 }


### PR DESCRIPTION
There could be a case when Varien_autoload already unregistered in another module (for example in Magento-PSR-0-Autoloader). So, I add checks about original autoload is null or not.